### PR TITLE
donate.gnome.org aliases

### DIFF
--- a/roles/postfix.server/templates/postmap/virtual-gnome.org.j2
+++ b/roles/postfix.server/templates/postmap/virtual-gnome.org.j2
@@ -78,14 +78,19 @@ accounts@gnome.org accounting@gnome.org
 hiring-committee@gnome.org edsearch-list@gnome.org
 
 # 2024 Contractor Positions
-flathub@gnome.org ramcq@gnome.org,allanday@gnome.org,bpiotrowski
+flathub@gnome.org ramcq@gnome.org,allanday@gnome.org,bpiotrowski,steven@gnome.org
 wellbeing@gnome.org ramcq@gnome.org,allanday@gnome.org,pwithnall@gnome.org,steven@gnome.org
 developmentfund@gnome.org ramcq@gnome.org,allanday@gnome.org,jsparber@gnome.org
 
 # University Outreach (https://gitlab.gnome.org/Infrastructure/Infrastructure/issues/254)
 universityoutreach@gnome.org kprogri@gnome.org, nkemregina@gnome.org
 
-friends@gnome.org zana@gnome.org, tobiasmue@gnome.org
+# donate.gnome.org
+donate@gnome.org   director@gnome.org, bpiotrowski, av@gnome.org
+friends@gnome.org  director@gnome.org, bpiotrowski, av@gnome.org
+sponsors@gnome.org director@gnome.org, bpiotrowski, av@gnome.org
+
+# old campaigns
 friends-eu@gnome.org director@gnome.org,zana@gnome.org
 tshirts@gnome.org drfickle@k-lug.org
 gear@gnome.org drfickle@k-lug.org


### PR DESCRIPTION
* donate@ - used for admin, Gravatar account, etc.
* friends@ - FoG has been co-opted for recurring donations
* sponsors@ - corporate sponsors can reach us here (not published)
* added myself to flathub@