### PR TITLE
hetzner-1: Mount /tmp as a tmpfs

### DIFF
--- a/inventory/host_vars/hetzner-1
+++ b/inventory/host_vars/hetzner-1
@@ -57,6 +57,8 @@ gitlab_runner_config:
         cap_add:
           - SYS_PTRACE
           - SYS_CHROOT
+        tmpfs:
+          "/tmp": "rw,nosuid,nodev,exec,mode=1777"
     - name: a15948139c78-flatpak
       url: https://gitlab.gnome.org
       id: 460
@@ -83,3 +85,5 @@ gitlab_runner_config:
         oom_kill_disable: false
         disable_cache: true
         shm_size: 0
+        tmpfs:
+          "/tmp": "rw,nosuid,nodev,exec,mode=1777"


### PR DESCRIPTION
Otherwise by default its located in the contianer
rootfs overlayfs and its weird