### PR TITLE
gitlab-runners: Mount /tmp as a tmpfs always

### DIFF
--- a/inventory/host_vars/azure-aarch64-01
+++ b/inventory/host_vars/azure-aarch64-01
@@ -33,6 +33,8 @@ gitlab_runner_config:
         oom_kill_disable: false
         disable_cache: true
         shm_size: 0
+        tmpfs:
+          "/tmp": "rw,nosuid,nodev,exec,mode=1777"
     - name: YxdEp3-Hx
       url: https://gitlab.gnome.org
       id: 726
@@ -57,3 +59,5 @@ gitlab_runner_config:
         cap_add:
           - SYS_PTRACE
           - SYS_CHROOT
+        tmpfs:
+          "/tmp": "rw,nosuid,nodev,exec,mode=1777"

--- a/inventory/host_vars/bbb2-runner
+++ b/inventory/host_vars/bbb2-runner
@@ -48,6 +48,8 @@ gitlab_runner_config:
         cap_add:
           - SYS_PTRACE
           - SYS_CHROOT
+        tmpfs:
+          "/tmp": "rw,nosuid,nodev,exec,mode=1777"
     - name: a15948139c78-flatpak
       url: https://gitlab.gnome.org
       id: 460
@@ -69,3 +71,5 @@ gitlab_runner_config:
         oom_kill_disable: false
         disable_cache: true
         shm_size: 0
+        tmpfs:
+          "/tmp": "rw,nosuid,nodev,exec,mode=1777"

--- a/inventory/host_vars/dh-aarch64-01
+++ b/inventory/host_vars/dh-aarch64-01
@@ -45,6 +45,8 @@ gitlab_runner_config:
         cap_add:
           - SYS_PTRACE
           - SYS_CHROOT
+        tmpfs:
+          "/tmp": "rw,nosuid,nodev,exec,mode=1777"
     - name: a15948139c78-flatpak
       url: https://gitlab.gnome.org
       id: 460
@@ -68,3 +70,5 @@ gitlab_runner_config:
         oom_kill_disable: false
         disable_cache: true
         shm_size: 0
+        tmpfs:
+          "/tmp": "rw,nosuid,nodev,exec,mode=1777"

--- a/inventory/host_vars/dh-aarch64-02
+++ b/inventory/host_vars/dh-aarch64-02
@@ -45,6 +45,8 @@ gitlab_runner_config:
         cap_add:
           - SYS_PTRACE
           - SYS_CHROOT
+        tmpfs:
+          "/tmp": "rw,nosuid,nodev,exec,mode=1777"
     - name: a15948139c78-flatpak
       url: https://gitlab.gnome.org
       id: 460
@@ -68,3 +70,5 @@ gitlab_runner_config:
         oom_kill_disable: false
         disable_cache: true
         shm_size: 0
+        tmpfs:
+          "/tmp": "rw,nosuid,nodev,exec,mode=1777"

--- a/inventory/host_vars/hetzner-2
+++ b/inventory/host_vars/hetzner-2
@@ -55,6 +55,8 @@ gitlab_runner_config:
         cap_add:
           - SYS_PTRACE
           - SYS_CHROOT
+        tmpfs:
+          "/tmp": "rw,nosuid,nodev,exec,mode=1777"
     - name: a15948139c78-flatpak
       url: https://gitlab.gnome.org
       id: 460
@@ -79,3 +81,5 @@ gitlab_runner_config:
         oom_kill_disable: false
         disable_cache: true
         shm_size: 0
+        tmpfs:
+          "/tmp": "rw,nosuid,nodev,exec,mode=1777"

--- a/inventory/host_vars/hetzner-3
+++ b/inventory/host_vars/hetzner-3
@@ -53,6 +53,8 @@ gitlab_runner_config:
         cap_add:
           - SYS_PTRACE
           - SYS_CHROOT
+        tmpfs:
+          "/tmp": "rw,nosuid,nodev,exec,mode=1777"
     - name: a15948139c78-flatpak
       url: https://gitlab.gnome.org
       id: 460
@@ -75,3 +77,5 @@ gitlab_runner_config:
         oom_kill_disable: false
         disable_cache: true
         shm_size: 0
+        tmpfs:
+          "/tmp": "rw,nosuid,nodev,exec,mode=1777"

--- a/inventory/host_vars/osuosl-1
+++ b/inventory/host_vars/osuosl-1
@@ -49,6 +49,8 @@ gitlab_runner_config:
         cap_add:
           - SYS_PTRACE
           - SYS_CHROOT
+        tmpfs:
+          "/tmp": "rw,nosuid,nodev,exec,mode=1777"
     - name: a15948139c78-flatpak
       url: https://gitlab.gnome.org
       id: 460
@@ -70,3 +72,5 @@ gitlab_runner_config:
         oom_kill_disable: false
         disable_cache: true
         shm_size: 0
+        tmpfs:
+          "/tmp": "rw,nosuid,nodev,exec,mode=1777"

--- a/inventory/host_vars/osuosl-2
+++ b/inventory/host_vars/osuosl-2
@@ -33,6 +33,8 @@ gitlab_runner_config:
         oom_kill_disable: false
         disable_cache: true
         shm_size: 0
+        tmpfs:
+          "/tmp": "rw,nosuid,nodev,exec,mode=1777"
     - name: osuosl-2-gnome-release-service-ptyxis
       url: https://gitlab.gnome.org
       id: 858
@@ -46,3 +48,5 @@ gitlab_runner_config:
         oom_kill_disable: false
         disable_cache: true
         shm_size: 0
+        tmpfs:
+          "/tmp": "rw,nosuid,nodev,exec,mode=1777"

--- a/inventory/host_vars/osuosl-arm1
+++ b/inventory/host_vars/osuosl-arm1
@@ -42,6 +42,8 @@ gitlab_runner_config:
           - /var/cache/gnome-build-meta:/cache
           - casd_socket:/run/casd
         shm_size: 256000000
+        tmpfs:
+          "/tmp": "rw,nosuid,nodev,exec,mode=1777"
     - name: osuosl-arm1-flatpak
       output_limit: 16384
       url: https://gitlab.gnome.org/
@@ -64,6 +66,8 @@ gitlab_runner_config:
         volumes:
           - /proc:/host/proc
         shm_size: 0
+        tmpfs:
+          "/tmp": "rw,nosuid,nodev,exec,mode=1777"
 
 gitlab_runner_buildbox_casd: true
 gitlab_runner_buildbox_casd_jobs: 4

--- a/inventory/host_vars/redhat-runner-01
+++ b/inventory/host_vars/redhat-runner-01
@@ -39,3 +39,5 @@ gitlab_runner_config:
         cap_add:
           - SYS_PTRACE
           - SYS_CHROOT
+        tmpfs:
+          "/tmp": "rw,nosuid,nodev,exec,mode=1777"

--- a/inventory/host_vars/redhat-runner-02
+++ b/inventory/host_vars/redhat-runner-02
@@ -39,3 +39,5 @@ gitlab_runner_config:
         cap_add:
           - SYS_PTRACE
           - SYS_CHROOT
+        tmpfs:
+          "/tmp": "rw,nosuid,nodev,exec,mode=1777"

--- a/inventory/host_vars/redhat-runner-03
+++ b/inventory/host_vars/redhat-runner-03
@@ -32,6 +32,8 @@ gitlab_runner_config:
           - /home/podman/cache:/cache
           - casd_socket:/run/casd
         shm_size: 0
+        tmpfs:
+          "/tmp": "rw,nosuid,nodev,exec,mode=1777"
 
 gitlab_runner_buildbox_casd: true
 gitlab_runner_buildbox_casd_jobs: 8


### PR DESCRIPTION
Otherwise podman/docker default with the /tmp
directory being placed in the root / mount point
and inside the container volume.

Mount it as a tmpfs as usually expected in systems.

This way, it also means that the /tmp will not
persist in the container volumes and across runs
as well.

This is equivalent to passing the following during runner registration.

--docker-tmpfs /tmp:rw,nosuid,nodev,exec,mode=1777

Followup to 0fd1871d6df2a09cfb147842c948969e273532dc