### PR TITLE
Copy foundation-staff-archive on all important emails

### DIFF
--- a/roles/postfix.server/templates/postmap/virtual-gnome.org.j2
+++ b/roles/postfix.server/templates/postmap/virtual-gnome.org.j2
@@ -32,7 +32,7 @@ gnome-mirror-admins@gnome.org archive@ftp.sunet.se,help@mirrorservice.org,veilla
 # GUADEC
 
 guadec-logos@gnome.org guadec-planning@gnome.org
-guadec@gnome.org zana@gnome.org, kprogri@gnome.org
+guadec@gnome.org zana@gnome.org, kprogri@gnome.org, foundation-staff-archive@gnome.org
 
 # On request from Ekaterina Gerasimova on 2016-02-04
 patreon@gnome.org kat@gnome.org
@@ -56,12 +56,12 @@ board@gnome.org gitlab-servicedesk-forwarder@gnome.org
 
 # Staff and general info
 info@gnome.org steven@gnome.org,zana@gnome.org,kprogri@gnome.org,akuci@gnome.org
-staff@gnome.org steven@gnome.org,zana@gnome.org,kprogri@gnome.org,akuci@gnome.org,bpiotrowski
+staff@gnome.org steven@gnome.org,zana@gnome.org,kprogri@gnome.org,akuci@gnome.org,bpiotrowski,foundation-staff-archive@gnome.org
 events@gnome.org info@gnome.org
 hmillion@gnome.org info@gnome.org
 instagram@gnome.org info@gnome.org
 licensing@gnome.org info@gnome.org
-microblog@gnome.org info@gnome.org, bpiotrowski, pietrodc@gnome.org, cassidyjames@gnome.org
+microblog@gnome.org info@gnome.org, bpiotrowski, pietrodc@gnome.org, cassidyjames@gnome.org, foundation-staff-archive@gnome.org
 neil@gnome.org info@gnome.org
 neilm@gnome.org info@gnome.org
 pia-affiliate@gnome.org info@gnome.org
@@ -69,9 +69,12 @@ sponsorship@gnome.org info@gnome.org
 support@gnome.org info@gnome.org
 video@gnome.org info@gnome.org
 
+# Legal
+legal@gnome.org director@gnome.org, foundation-staff-archive@gnome.org
+
 # Accounting aliases
-bookkeeper@gnome.org rebecca.selin.services@gmail.com
-accounting@gnome.org zana@gnome.org,akuci@gnome.org,steven@gnome.org
+bookkeeper@gnome.org rebecca.selin.services@gmail.com, foundation-staff-archive@gnome.org
+accounting@gnome.org zana@gnome.org,akuci@gnome.org,steven@gnome.org, foundation-staff-archive@gnome.org
 accounts@gnome.org accounting@gnome.org
 
 # Hiring Committee
@@ -91,15 +94,15 @@ friends@gnome.org  director@gnome.org, bpiotrowski, av@gnome.org
 sponsors@gnome.org director@gnome.org, bpiotrowski, av@gnome.org
 
 # old campaigns
-friends-eu@gnome.org director@gnome.org,zana@gnome.org
+friends-eu@gnome.org director@gnome.org,zana@gnome.org,foundation-staff-archive@gnome.org
 tshirts@gnome.org drfickle@k-lug.org
 gear@gnome.org drfickle@k-lug.org
 # Groupon fundraising campaign Paypal address
-defendus@gnome.org zana@gnome.org
+defendus@gnome.org zana@gnome.org,director@gnome.org,foundation-staff-archive@gnome.org
 
 # Alias used for donations taken on behalf of the GIMP project
 # Rosanna Yuen, Michael Natterer, Michael Schumacher
-gimp@gnome.org mitch@gimp.org, zana@gnome.org, schumaml@gmx.de
+gimp@gnome.org mitch@gimp.org, zana@gnome.org, schumaml@gmx.de, director@gnome.org, foundation-staff-archive@gnome.org
 
 # Personal aliases.
 aday@gnome.org allanday@gnome.org
@@ -127,7 +130,7 @@ thib@gnome.org thibaultamartin@gnome.org
 marketing-list@gnome.org engagement-list@gnome.org
 
 # Used for Amazon Affiliates
-amazon@gnome.org zana@gnome.org
+amazon@gnome.org zana@gnome.org, director@gnome.org, foundation-staff-archive@gnome.org
 
 # Used for Twitter (@GNOMELove)
 gnomelove@gnome.org allanpday@gmail.com
@@ -175,7 +178,7 @@ compensation-committee@gnome.org csoriano@gnome.org, ramcq@gnome.org, nuritzi@gn
 photos@gnome.org cassandra@gnome.org, nuritzi@gnome.org, adeliar@gnome.org
 
 # Libre Graphics Meeting donations (Davy Neary) (RT#4535)
-lgm@gnome.org dneary@gnome.org,louis.desjardins@gmail.com,kamila.giedrojc@gmail.com,jon@rejon.org,zana@gnome.org
+lgm@gnome.org dneary@gnome.org,louis.desjardins@gmail.com,kamila.giedrojc@gmail.com,jon@rejon.org,zana@gnome.org,foundation-staff-archive@gnome.org
 
 # On request from Emmanuele Bassi for clutter's project blog on blogs.g.o (averi - 08/10/2012)
 clutter@gnome.org ebassi@gmail.com
@@ -185,7 +188,7 @@ asia-summit@gnome.org gnomecn@gmail.com, x2rich@gmail.com, emily.chen@sun.com, m
 
 # PiTivi Fundraising campaign
 pitivi-fundraiser@gnome.org saunierthibault@gmail.com, mduponchelle1@gmail.com
-pitivi@gnome.org zana@gnome.org, saunierthibault@gmail.com, mduponchelle1@gmail.com
+pitivi@gnome.org zana@gnome.org, saunierthibault@gmail.com, mduponchelle1@gmail.com, director@gnome.org, foundation-staff-archive@gnome.org
 
 # https://gitlab.gnome.org/Infrastructure/Infrastructure/-/issues/440
 outreach@gnome.org sri@gnome.org
@@ -226,7 +229,7 @@ gitlab-issues@gnome.org devnull
 
 ### OWP Aliases && SOC aliases
 gnome-opw-admins@gnome.org marinaz@redhat.com, karen@gnome.org, kittykat3756@gmail.com
-opw-admins@gnome.org marinaz@redhat.com, karen@gnome.org, zana@gnome.org, sarah@thesharps.us
+opw-admins@gnome.org marinaz@redhat.com, karen@gnome.org, zana@gnome.org, sarah@thesharps.us, foundation-staff-archive@gnome.org
 
 ## Bug 634461
 opw-interns-2010@gnome.org tiffany.antopolski@gmail.com, nancibonfim@gmail.com, luciana@fujii.eti.br, genia.likes.science@gmail.com, stringarray@gmail.com, hellyna@hellyna.com, chandniverma2112@gmail.com
@@ -314,10 +317,10 @@ gnomeasia@gnome.org kprogri@gnome.org
 conduct@gnome.org gitlab-servicedesk-forwarder@gnome.org
 
 # https://gitlab.gnome.org/Infrastructure/Infrastructure/-/issues/1100
-coc@gnome.org federico@gnome.org, zana@gnome.org, akuci@gnome.org, mdowney@gnome.org, christopherdavis@gnome.org, carlosg@gnome.org
+coc@gnome.org federico@gnome.org, zana@gnome.org, akuci@gnome.org, mdowney@gnome.org, christopherdavis@gnome.org, carlosg@gnome.org, foundation-staff-archive@gnome.org
 
 # GUADEC shop, requested by Kristi Progri on 2020-05-08
-shop@gnome.org zana@gnome.org, kprogri@gnome.org
+shop@gnome.org zana@gnome.org, kprogri@gnome.org, director@gnome.org, foundation-staff-archive@gnome.org
 
 # GUADEC headshots
 headshots@gnome.org guadec-headshots-list@gnome.org
@@ -408,7 +411,7 @@ board-list@gnome.org gitlab-servicedesk-forwarder@gnome.org
 code-of-conduct-committee@gnome.org gitlab-servicedesk-forwarder@gnome.org
 docs-feedback@gnome.org gitlab-servicedesk-forwarder@gnome.org
 ftp-release-notifications@gnome.org zaitor@opensuse.org, leio@gentoo.org, mattst88@gentoo.org, heftig@archlinux.org, luc14n0@opensuse.org, pacho@gentoo.org, kalevlember@gmail.com, jbicha@ubuntu.com, emilyyrose@gmail.com, bandali@canonical.com, casaxa@gmail.com, nathan.teodosio@canonical.com, jarred.wilson12@gmail.com
-fundraising@gnome.org board@gnome.org,zana@gnome.org
+fundraising@gnome.org board@gnome.org, zana@gnome.org, director@gnome.org, foundation-staff-archive@gnome.org
 gitlab-abuse-reports@gnome.org gitlab-servicedesk-forwarder@gnome.org
 travel-committee@gnome.org travel-committee@discourse.gnome.org
 

--- a/roles/postfix.server/templates/postmap/virtual-gnome.org.j2
+++ b/roles/postfix.server/templates/postmap/virtual-gnome.org.j2
@@ -55,8 +55,8 @@ gcalctool-list@gnome.org gnome-calculator-list@gnome.org
 board@gnome.org gitlab-servicedesk-forwarder@gnome.org
 
 # Staff and general info
-info@gnome.org steven@gnome.org,zana@gnome.org,kprogri@gnome.org,akuci@gnome.org
-staff@gnome.org steven@gnome.org,zana@gnome.org,kprogri@gnome.org,akuci@gnome.org,bpiotrowski,foundation-staff-archive@gnome.org
+info@gnome.org director@gnome.org,zana@gnome.org,kprogri@gnome.org,akuci@gnome.org
+staff@gnome.org director@gnome.org,zana@gnome.org,kprogri@gnome.org,akuci@gnome.org,bpiotrowski,foundation-staff-archive@gnome.org
 events@gnome.org info@gnome.org
 hmillion@gnome.org info@gnome.org
 instagram@gnome.org info@gnome.org
@@ -74,15 +74,15 @@ legal@gnome.org director@gnome.org, foundation-staff-archive@gnome.org
 
 # Accounting aliases
 bookkeeper@gnome.org rebecca.selin.services@gmail.com, foundation-staff-archive@gnome.org
-accounting@gnome.org zana@gnome.org,akuci@gnome.org,steven@gnome.org, foundation-staff-archive@gnome.org
+accounting@gnome.org zana@gnome.org,akuci@gnome.org,director@gnome.org, foundation-staff-archive@gnome.org
 accounts@gnome.org accounting@gnome.org
 
 # Hiring Committee
 hiring-committee@gnome.org edsearch-list@gnome.org
 
 # 2024 Contractor Positions
-flathub@gnome.org ramcq@gnome.org,allanday@gnome.org,bpiotrowski,steven@gnome.org
-wellbeing@gnome.org ramcq@gnome.org,allanday@gnome.org,pwithnall@gnome.org,steven@gnome.org
+flathub@gnome.org ramcq@gnome.org,allanday@gnome.org,bpiotrowski,director@gnome.org
+wellbeing@gnome.org ramcq@gnome.org,allanday@gnome.org,pwithnall@gnome.org,director@gnome.org
 developmentfund@gnome.org ramcq@gnome.org,allanday@gnome.org,jsparber@gnome.org
 
 # University Outreach (https://gitlab.gnome.org/Infrastructure/Infrastructure/issues/254)


### PR DESCRIPTION
@averi I saw you reverted your foundation-staff-archive commit... not sure if this was intentional? Just thought I'd give you a heads-up in case it wasn't.

This PR:

* copies foundation-staff-archive
* removes `steven@` from all aliases and replaces with `director@`
  * [ ] pending: all aliases should reflect staff roles, not individuals ... a job for another day