### PR TITLE
postfix: add director@ to registration@las.gnome.org

### DIFF
--- a/roles/postfix.server/templates/postmap/virtual-las.gnome.org.j2
+++ b/roles/postfix.server/templates/postmap/virtual-las.gnome.org.j2
@@ -3,4 +3,4 @@ papers@las.gnome.org talks@las.gnome.org
 talks@las.gnome.org    robert@mcqueen.me.uk,sri@ramkrishna.me,cosimo.cecchi@gmail.com,megford@gnome.org,philip@tecnocode.co.uk,aleixpol@kde.org
 info@las.gnome.org      sri@ramkrishna.me,adeliarahim@gmail.com,nuritzis@gmail.com
 sponsors@las.gnome.org  zana@gnome.org,sri@ramkrishna.me
-registration@las.gnome.org  zana@gnome.org 
+registration@las.gnome.org  zana@gnome.org,director@gnome.org


### PR DESCRIPTION
This appears to be used for our PayPal account 2FA and I have some changes to make.