### PR TITLE
Create a new alias to be used for the Snap Store.

### DIFF
--- a/roles/postfix.server/templates/postmap/virtual-gimp.org.j2
+++ b/roles/postfix.server/templates/postmap/virtual-gimp.org.j2
@@ -310,3 +310,6 @@ msstore@gimp.org jernej|s-gimp@eternallybored.org, jgboerema@gmail.com, mitch@gi
 
 # https://gitlab.gnome.org/Infrastructure/Infrastructure/-/issues/844
 security@gimp.org jernej|s-gimp@eternallybored.org, jgboerema@gmail.com, mitch@gimp.org, schumaml@gmx.de, jehan@gimp.org, liam@fromoldbooks.org
+
+# Email to be used for the snap store.
+snap@gimp.org brunolopesdsilv@outlook.com, jehan@gimp.org


### PR DESCRIPTION
We are taking over the Snap on Ubuntu's Snap Store so we'll create an account there with an official email address.

See: https://github.com/snapcrafters/gimp/pull/460#issuecomment-3356858840