### PR TITLE
Redirect STF email

### DIFF
--- a/roles/postfix.server/templates/postmap/virtual-gnome.org.j2
+++ b/roles/postfix.server/templates/postmap/virtual-gnome.org.j2
@@ -76,6 +76,7 @@ accounts@gnome.org accounting@gnome.org
 director@gnome.org exec@gnome.org
 tutorials@gnome.org info@gnome.org
 executive@gnome.org exec@gnome.org
+stf@gnome.org tbernard@gnome.org, adrianvovk@gmail.com, exec@gnome.org
 
 # Foundation officers
 president@gnome.org aday@gnome.org, ramcq@gnome.org, arunsr@gnome.org, foundation-staff-archive@gnome.org
@@ -322,9 +323,6 @@ gtk-social@gnome.org ebassi@gnome.org
 # Bot user for managing mirrors with Lorry
 # https://gitlab.gnome.org/Infrastructure/Infrastructure/-/issues/705
 lorry-controller-gitlab-bot@gnome.org gnome-sysadmin@gnome.org
-
-# STF (requested by Sonny Piers)
-stf@gnome.org tbernard@gnome.org, adrianvovk@gmail.com, president@gnome.org, accounting@gnome.org
 
 # Spamtrap
 /^.*@cvs.gnome.org$/ spamtrap@gnome.org


### PR DESCRIPTION
stf@gnome.org was being used by a payment platform on the Foundation. This has now been switched over to accounting@gnome.org, in order to consolidate finance notifications in one place.