### PR TITLE
buildbox-casd: increase the number of threads used to hash files

### DIFF
--- a/roles/gitlab-runner/tasks/main.yml
+++ b/roles/gitlab-runner/tasks/main.yml
@@ -227,6 +227,7 @@
       - >-
           "rm -rf /srv/cas/cas/tmp /srv/cas/cas/staging;
           exec buildbox-casd --buildbox-run buildbox-run-bubblewrap --jobs {{ gitlab_runner_buildbox_casd_jobs }}
+          --num-digest-threads {{ gitlab_runner_buildbox_casd_jobs }}
           --metrics-mode udp://host.containers.internal:9125 --cache-failures false
           --bind unix:/run/casd/casd.sock --reserved {{ gitlab_runner_buildbox_casd_reserved }} /srv/cas"
     quadlet_filename: buildbox-casd


### PR DESCRIPTION
Let's match the number of jobs for now